### PR TITLE
Fix encrypting messages with 8bit transfer encoding in Python2

### DIFF
--- a/smime/block.py
+++ b/smime/block.py
@@ -51,7 +51,7 @@ class AES(BlockCipher):
     def encrypt(self, data):
         padded_data = self._pad(data, self.block_size)
         encrypted_content = (
-            self._encryptor.update(padded_data.encode("utf-8"))
+            self._encryptor.update(padded_data)
             + self._encryptor.finalize()
         )
         return {

--- a/smime/encrypt.py
+++ b/smime/encrypt.py
@@ -54,6 +54,9 @@ def encrypt(message, certs, algorithm="aes256_cbc"):
             headers[hdr_name] = values
 
     content = copied_msg.as_string()
+    # .as_string() returns Unicode string in py3, byte string in py2
+    if isinstance(content, unicode):
+        content = content.encode("utf-8")
     recipient_infos = []
 
     for recipient_info in __iterate_recipient_infos(certs, block_cipher.session_key):


### PR DESCRIPTION
When Content-Transfer-Encoding header is set to "8bit", the message flattened as a string may contain non-ascii characters.
encrypt() shouldn't try to re-encode them as UTF-8 because the message encoding may not match system default, so these characters cannot be converted to Unicode.